### PR TITLE
Enable to send line notification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "bootsnap", require: false
 
 gem 'graphql', "< 2.1"
 gem 'graphql-client'
+gem 'line-bot-api'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     irb (1.8.1)
       rdoc
       reline (>= 0.3.8)
+    line-bot-api (1.28.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -211,6 +212,7 @@ DEPENDENCIES
   graphiql-rails
   graphql (< 2.1)
   graphql-client
+  line-bot-api
   pry-byebug
   pry-rails
   puma (~> 5.0)

--- a/app/controllers/octopus_energy_bill_controller.rb
+++ b/app/controllers/octopus_energy_bill_controller.rb
@@ -35,11 +35,27 @@ class OctopusEnergyBillController < ApplicationController
       fromDatetime: Date.yesterday.beginning_of_day.iso8601,
       toDatetime: Date.yesterday.end_of_day.iso8601
       })
+
     properties = result.original_hash.dig("data", "account", "properties")
     electricity_supply_points = properties.first["electricitySupplyPoints"]
     half_hourly_readings = electricity_supply_points.first["halfHourlyReadings"]
     @kwh = half_hourly_readings.pluck("value").map(&:to_f).sum
     @cost = half_hourly_readings.pluck("costEstimate").map(&:to_f).sum
-    puts "#{Date.yesterday.strftime('%Y年%m月%d日')}は#{@kwh.round(2)}kWh消費して#{@cost}円かかったよ" 
+    text = "#{Date.yesterday.strftime('%Y年%m月%d日')}は#{@kwh.round(2)}kWh消費して#{@cost}円かかったよ" 
+
+		message = {
+      type: 'text',
+      text: text
+    }
+    client.broadcast(message)
   end
+
+	private
+
+	def client 
+		@client ||= Line::Bot::Client.new { |config|
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    }
+	end
 end

--- a/app/controllers/octopus_energy_bill_controller.rb
+++ b/app/controllers/octopus_energy_bill_controller.rb
@@ -1,32 +1,32 @@
 class OctopusEnergyBillController < ApplicationController
 
-  GetBillQUERY = OctopusClient::Client.parse <<~'GRAPHQL'
-	query(
-		$accountNumber: String!
-		$fromDatetime: DateTime
-		$toDatetime: DateTime
-	) {
-		account(accountNumber: $accountNumber) {
-			properties {
-				electricitySupplyPoints {
-					agreements {
-						validFrom
-					}
-					halfHourlyReadings(
-						fromDatetime: $fromDatetime
-						toDatetime: $toDatetime
-					) {
-						startAt
-            endAt
-						value
-						costEstimate
-						consumptionStep
-						consumptionRateBand
+	GetBillQUERY = OctopusClient::Client.parse <<~'GRAPHQL'
+		query(
+			$accountNumber: String!
+			$fromDatetime: DateTime
+			$toDatetime: DateTime
+		) {
+			account(accountNumber: $accountNumber) {
+				properties {
+					electricitySupplyPoints {
+						agreements {
+							validFrom
+						}
+						halfHourlyReadings(
+							fromDatetime: $fromDatetime
+							toDatetime: $toDatetime
+						) {
+							startAt
+							endAt
+							value
+							costEstimate
+							consumptionStep
+							consumptionRateBand
+						}
 					}
 				}
 			}
 		}
-	}
   GRAPHQL
 
   def index 
@@ -47,15 +47,6 @@ class OctopusEnergyBillController < ApplicationController
       type: 'text',
       text: text
     }
-    client.broadcast(message)
+		LineBotClient.new.client.broadcast(message)
   end
-
-	private
-
-	def client 
-		@client ||= Line::Bot::Client.new { |config|
-      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
-      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
-    }
-	end
 end

--- a/lib/line_bot_client.rb
+++ b/lib/line_bot_client.rb
@@ -1,0 +1,8 @@
+class LineBotClient
+  def client 
+    Line::Bot::Client.new { |config|
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    }
+  end
+end


### PR DESCRIPTION
## What
closes https://github.com/kimkim0814/octopus-energy-line-bot/issues/2

## How
- `line-bot-api`を導入する
-  Line bot clientをprivateメソッドで実装
-  client メソッドを用いて `/octopus_energy_bill`を叩いた際にLINE通知が送られるようにする
## Why