### PR TITLE
Create task for get energy bill

### DIFF
--- a/app/services/octopus_energy_bill.rb
+++ b/app/services/octopus_energy_bill.rb
@@ -1,0 +1,52 @@
+class OctopusEnergyBill
+
+	GetBillQUERY = OctopusClient::Client.parse <<~'GRAPHQL'
+		query(
+			$accountNumber: String!
+			$fromDatetime: DateTime
+			$toDatetime: DateTime
+		) {
+			account(accountNumber: $accountNumber) {
+				properties {
+					electricitySupplyPoints {
+						agreements {
+							validFrom
+						}
+						halfHourlyReadings(
+							fromDatetime: $fromDatetime
+							toDatetime: $toDatetime
+						) {
+							startAt
+							endAt
+							value
+							costEstimate
+							consumptionStep
+							consumptionRateBand
+						}
+					}
+				}
+			}
+		}
+  GRAPHQL
+
+  def notify
+    result = OctopusClient::Client.query(GetBillQUERY, variables: {
+      accountNumber: ENV['OCTOPUS_ACCOUNT_NUMBER'],
+      fromDatetime: Date.yesterday.beginning_of_day.iso8601,
+      toDatetime: Date.yesterday.end_of_day.iso8601
+      })
+
+    properties = result.original_hash.dig("data", "account", "properties")
+    electricity_supply_points = properties.first["electricitySupplyPoints"]
+    half_hourly_readings = electricity_supply_points.first["halfHourlyReadings"]
+    @kwh = half_hourly_readings.pluck("value").map(&:to_f).sum
+    @cost = half_hourly_readings.pluck("costEstimate").map(&:to_f).sum
+    text = "#{Date.yesterday.strftime('%Y年%m月%d日')}は#{@kwh.round(2)}kWh消費して#{@cost}円かかったよ"
+
+		message = {
+      type: 'text',
+      text: text
+    }
+		LineBotClient.new.client.broadcast(message)
+  end
+end

--- a/lib/tasks/line_notification.rake
+++ b/lib/tasks/line_notification.rake
@@ -1,0 +1,6 @@
+namespace :line_notification do
+  desc "Send billing notification"
+  task send_billing_notification: :environment do
+    OctopusEnergyBill.new.notify
+  end
+end


### PR DESCRIPTION
## What
closes https://github.com/kimkim0814/octopus-energy-line-bot/issues/3
## How 
- `app/services/octopus_energy_bill.rb`に電気代を取得して通知するロジックを移植
- `lib/tasks`配下に上記を叩くタスクを作成
## Why